### PR TITLE
:sparkles: Update deprecated use of ::set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,13 +11,13 @@ runs:
         if git diff --staged --binary --exit-code > /tmp/fix.diff
         then
           echo 'CI worktree is clean.'
-          echo '::set-output name=result::clean'
+          echo 'result=clean' >> $GITHUB_OUTPUT
         else
           echo '::error::CI worktree is dirty.'
-          echo '::set-output name=result::dirty'
+          echo 'result=dirty' >> $GITHUB_OUTPUT
         fi
       shell: bash
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: steps.diff.outputs.result == 'dirty'
       with:
         name: git-patch


### PR DESCRIPTION
Github deprecated the `::set-output` command for stdin, see [the blog post for details](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).
This patch switches the action to the new way of doing it.